### PR TITLE
basic date picker from simple_form_for

### DIFF
--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -61,7 +61,7 @@
           <div class="d-none" data-booker-target="calendar">
             <%= simple_form_for [@post, @reservation] do |f| %>
               <%= f.hidden_field  :profile_id, :value => profile.id   %>
-              <%= f.input :start_date, as: :date, html5: true %>
+              <%= f.input :start_date, as: :datetime, html5: true %>
 
               <%= f.submit 'Confirmar', class: 'btn-campanazzo' %>
             <% end %>


### PR DESCRIPTION
NOTE:  The gem flatpickr was not required, and rather I just added the datepicker from simple_form_for

      <%= simple_form_for [@post, @reservation] do |f| %>
              <%= f.hidden_field  :profile_id, :value => profile.id   %>
              <%= f.input :start_date, as: :datetime, html5: true %>

              <%= f.submit 'Confirmar', class: 'btn-campanazzo' %>
            <% end %>